### PR TITLE
Updated name of pitchmax variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ qf = [500., 350., 100., deg2rad(0.), deg2rad(-5.)]
 # Minimum turning radius
 rhomin = 40.
 # Pich angle constraints [min_pitch, max_pitch]
-pitchmax = deg2rad.([-15., 20.])
+pitchlims = deg2rad.([-15., 20.])
 
-maneuver = DubinsManeuver3D(qi, qf, rhomin, pitchmax)
+maneuver = DubinsManeuver3D(qi, qf, rhomin, pitchlims)
 
 # Length of the 3D Dubins path
 @show maneuver.length

--- a/test/instances3D.jl
+++ b/test/instances3D.jl
@@ -3,7 +3,7 @@ Test intances collected mainly from various papers about 3D Dubins paths.
 """
 
 rhomin = 40.
-pitchmax = pi * [-15., 20.] / 180.
+pitchlims = pi * [-15., 20.] / 180.
 deg2rad(x) = pi * x / 180.
 
 LONG = [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,12 +7,12 @@ include("instances3D.jl")
 function print_results(data, name)
     @testset "Instances: $(name)" begin
         for (i, (qi, qf)) in enumerate(data)
-            dubins = DubinsManeuver3D(qi, qf, rhomin, pitchmax)
+            dubins = DubinsManeuver3D(qi, qf, rhomin, pitchlims)
   
-            t = @timed DubinsManeuver3D(qi, qf, rhomin, pitchmax)
+            t = @timed DubinsManeuver3D(qi, qf, rhomin, pitchlims)
   
-            lb = getLowerBound(qi, qf, rhomin, pitchmax)
-            ub = getUpperBound(qi, qf, rhomin, pitchmax)
+            lb = getLowerBound(qi, qf, rhomin, pitchlims)
+            ub = getUpperBound(qi, qf, rhomin, pitchlims)
             best_lb = lb.length
 
             @test lb.length <= dubins.length + 1e-5


### PR DESCRIPTION
When using the library for the first time, I was confused why the pitch angle is limited symmetrically. Then, I noticed that `pitchmax = [pitch_min, pitch_max]`. I consider it a little bit confusing to use `pitchmax` as a variable for pitch limits. Thus, I made a minor change by renaming it to `pitchlims`.